### PR TITLE
Implement persistent login registration

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,3 @@
+PORT=5000
+JWT_SECRET=your_jwt_secret
+DATABASE_URL=postgresql://user:password@localhost:5432/purchase_management

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS users (
+  id SERIAL PRIMARY KEY,
+  name TEXT NOT NULL,
+  email TEXT UNIQUE NOT NULL,
+  phone TEXT,
+  department TEXT,
+  employee_id TEXT,
+  role TEXT NOT NULL,
+  password TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/backend/src/data/users.ts
+++ b/backend/src/data/users.ts
@@ -1,3 +1,5 @@
+import { query } from '../db'
+
 export interface User {
   id: string
   name: string
@@ -9,4 +11,37 @@ export interface User {
   password: string
   createdAt: Date
   updatedAt: Date
+}
+
+export async function findUserByEmail(email: string): Promise<User | null> {
+  const result = await query('SELECT * FROM users WHERE email = $1', [email])
+  return result.rows[0] || null
+}
+
+interface CreateUserInput {
+  name: string
+  email: string
+  phone: string
+  department: string
+  employeeId: string
+  role: 'admin' | 'manager' | 'purchaser' | 'viewer'
+  password: string
+}
+
+export async function createUser(input: CreateUserInput): Promise<User> {
+  const result = await query(
+    `INSERT INTO users (name, email, phone, department, employee_id, role, password)
+     VALUES ($1, $2, $3, $4, $5, $6, $7)
+     RETURNING *`,
+    [
+      input.name,
+      input.email,
+      input.phone,
+      input.department,
+      input.employeeId,
+      input.role,
+      input.password,
+    ]
+  )
+  return result.rows[0]
 }

--- a/backend/src/db/index.ts
+++ b/backend/src/db/index.ts
@@ -1,0 +1,10 @@
+import { Pool } from 'pg'
+import dotenv from 'dotenv'
+
+dotenv.config()
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+})
+
+export const query = (text: string, params?: any[]) => pool.query(text, params)


### PR DESCRIPTION
## Summary
- create db connection helper
- persist users to Postgres instead of memory
- add user table schema
- document env vars

## Testing
- `npm run build` *(fails: Cannot find type definition file for modules)*

------
https://chatgpt.com/codex/tasks/task_e_6849a41b061c832bb035eafe0b80e320